### PR TITLE
onAVStarted pentru timing corect și opțiune pentru subtitrările externe

### DIFF
--- a/all/script.service.fastautosubs/resources/settings.xml
+++ b/all/script.service.fastautosubs/resources/settings.xml
@@ -7,6 +7,7 @@
         <setting id="check_for_specificb" type="bool" default="false" enable="eq(-2,true)" visible="eq(-2,true)" label="Caută încă o limbă"/>
         <setting id="selected_languageb" type="select" enable="eq(-1,true)+eq(-3,true)" visible="eq(-1,true)+eq(-3,true)" label="Limba secundară" default="English" values="Albanian|Arabic|Belarusian|Bosnian (Latin)|Bulgarian|Catalan|Chinese|Croatian|Czech|Danish|Dutch|English|Estonian|Finnish|French|German|Greek|Hebrew|Hindi|Hungarian|Icelandic|Indonesian|Italian|Japanese|Korean|Latvian|Lithuanian|Macedonian|Norwegian|Polish|Portuguese|Romanian|Russian|SerbianLatin|Slovak|Slovenian|Spanish|Swedish|Thai|Turkish|Ukrainian|Vietnamese|Farsi|Malay" />
         <setting id="check_for_external" type="bool" default="true" enable="eq(-4,true)" visible="eq(-4,true)" label="Include și subtitrarea necunoscută Externă"/>
+        <setting id="accept_any_external" type="bool" label="Acceptă orice subtitrare externă existentă" default="false"/>
         <setting id="ExcludeTime" type="number" label="Nu căuta pentru durate mai scurte de X minute" default="15"/>   	
         <setting id="ignore_words" type="text" default="theme,Sample" label="Ignoră cuvintele, separate cu virgulă"/>
 		<setting id="pause_on_search" type="bool" label="Pune pauză în timpul căutării automate" default="false" />

--- a/all/script.service.fastautosubs/service.py
+++ b/all/script.service.fastautosubs/service.py
@@ -45,6 +45,7 @@ ROMANIAN_LANG_CODES = ['rum', 'ro', 'ron', 'romanian']
 # CODURI PENTRU SUBTITRARI NECUNOSCUTE/EXTERNE
 # ==============================================================================
 UNKNOWN_EXTERNAL_CODES = ['und', 'unk', '', 'None', '(External)', 'External', 'external', 'Unknown', 'unknown']
+EXTERNAL_ONLY_CODES = ['', '(External)', 'External', 'external']
 
 
 def log(msg):
@@ -56,7 +57,7 @@ class AutoSubsPlayer(xbmc.Player):
         super(AutoSubsPlayer, self).__init__()
         self.wait = False
 
-    def onPlayBackStarted(self):
+    def onAVStarted(self):
         timeout = 0
         while self.isPlaying() and not self.isPlayingVideo() and timeout < 120:
             xbmc.sleep(250)
@@ -103,6 +104,12 @@ class AutoSubsPlayer(xbmc.Player):
             availableLangs = self.getAvailableSubtitleStreams()
         except:
             availableLangs = []
+
+        # Daca exista deja o subtitrare externa incarcata, o acceptam neconditionat
+        if __addon__.getSetting('accept_any_external') == 'true':
+            if any(l in EXTERNAL_ONLY_CODES for l in availableLangs):
+                log("Subtitrare externa detectata - acceptata")
+                return
         
         # Determinam tipul sursei
         is_local = self.is_local_source(movieFullPath)


### PR DESCRIPTION
- Înlocuit `onPlayBackStarted` cu `onAVStarted`: acesta se declanșează
  abia după ce Kodi a decodat efectiv primele cadre audio/video, când
  playerul e complet inițializat (inclusiv lista de de
  subtitrări). `onPlayBackStarted` se declanșa prea devreme, cauzând
  comportament nedorit (nu se căutau subtitrările uneori).

- Adăugarea opțiunii `accept_any_external`: dacă e activată și există deja
  o subtitrare externă încărcată, aceasta e acceptată necondiționat,
  fără căutare suplimentară. Opțiunea dată este `false` în modul inițial.
  
  Totul a fost testat și verificat. Mulțumesc!